### PR TITLE
Fix #3: Add necessary parameters to DeleteResourceRecordSet

### DIFF
--- a/src/Route53/Aliases/Route53Aliases.cs
+++ b/src/Route53/Aliases/Route53Aliases.cs
@@ -31,7 +31,7 @@ namespace Cake.AWS.Route53
 
 
         /// <summary>
-        /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers. 
+        /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers.
         /// The status of the zone changes to INSYNC when the NS and SOA records are available on all Route 53 DNS servers.
         /// </summary>
         /// <param name="context">The cake context.</param>
@@ -45,7 +45,7 @@ namespace Cake.AWS.Route53
         }
 
         /// <summary>
-        /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers. 
+        /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers.
         /// The status of the zone changes to INSYNC when the NS and SOA records are available on all Route 53 DNS servers.
         /// </summary>
         /// <param name="context">The cake context.</param>
@@ -124,7 +124,7 @@ namespace Cake.AWS.Route53
         /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
         /// <param name="name">The name of the DNS record set.</param>
         /// <param name="type">The type of the DNS record set.</param>
-        /// <param name="value">The value of the record set.</param> 
+        /// <param name="value">The value of the record set.</param>
         /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Route53")]
@@ -140,7 +140,7 @@ namespace Cake.AWS.Route53
         /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
         /// <param name="name">The name of the DNS record set.</param>
         /// <param name="type">The type of the DNS record set.</param>
-        /// <param name="value">The value of the record set.</param> 
+        /// <param name="value">The value of the record set.</param>
         /// <param name="ttl">The time to live of the record set.</param>
         /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
         [CakeMethodAlias]
@@ -157,12 +157,14 @@ namespace Cake.AWS.Route53
         /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
         /// <param name="name">The name of the DNS record set.</param>
         /// <param name="type">The type of the DNS record set.</param>
+        /// <param name="value">The value of the record set.</param>
+        /// <param name="ttl">The time to live of the record set.</param>
         /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
         [CakeMethodAlias]
         [CakeAliasCategory("Route53")]
-        public static string DeleteResourceRecordSet(this ICakeContext context, string hostedZoneId, string name, RRType type, Route53Settings settings)
+        public static string DeleteResourceRecordSet(this ICakeContext context, string hostedZoneId, string name, RRType type, string value, long ttl, Route53Settings settings)
         {
-            return context.CreateManager().DeleteResourceRecordSet(hostedZoneId, name, type, settings);
+            return context.CreateManager().DeleteResourceRecordSet(hostedZoneId, name, type, value, ttl, settings);
         }
 
         /// <summary>

--- a/src/Route53/Interfaces/IRoute53Manager.cs
+++ b/src/Route53/Interfaces/IRoute53Manager.cs
@@ -16,7 +16,7 @@ namespace Cake.AWS.Route53
     {
         #region Functions (7)
             /// <summary>
-            /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers. 
+            /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers.
             /// The status of the zone changes to INSYNC when the NS and SOA records are available on all Route 53 DNS servers.
             /// </summary>
             /// <param name="domain">The name of the domain</param>
@@ -55,7 +55,7 @@ namespace Cake.AWS.Route53
             /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
             /// <param name="name">The name of the DNS record set.</param>
             /// <param name="type">The type of the DNS record set.</param>
-            /// <param name="value">The value of the record set.</param> 
+            /// <param name="value">The value of the record set.</param>
             /// <param name="ttl">The time to live of the record set.</param>
             /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
             string CreateResourceRecordSet(string hostedZoneId, string name, RRType type, string value, long ttl, Route53Settings settings);
@@ -66,8 +66,10 @@ namespace Cake.AWS.Route53
             /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
             /// <param name="name">The name of the DNS record set.</param>
             /// <param name="type">The type of the DNS record set.</param>
+            /// <param name="value">The value of the record set.</param>
+            /// <param name="ttl">The time to live of the record set.</param>
             /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
-            string DeleteResourceRecordSet(string hostedZoneId, string name, RRType type, Route53Settings settings);
+            string DeleteResourceRecordSet(string hostedZoneId, string name, RRType type, string value, long ttl, Route53Settings settings);
 
             /// <summary>
             /// To retrieve a list of record sets for a particular hosted zone.

--- a/src/Route53/Manager/Route53Manager.cs
+++ b/src/Route53/Manager/Route53Manager.cs
@@ -65,7 +65,7 @@ namespace Cake.AWS.Route53
                 {
                     throw new ArgumentNullException("settings");
                 }
-                
+
                 if (settings.Region == null)
                 {
                     throw new ArgumentNullException("settings.Region");
@@ -135,7 +135,7 @@ namespace Cake.AWS.Route53
 
 
             /// <summary>
-            /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers. 
+            /// Create a new hosted zone. When you create a zone, its initial status is PENDING. This means that it is not yet available on all DNS servers.
             /// The status of the zone changes to INSYNC when the NS and SOA records are available on all Route 53 DNS servers.
             /// </summary>
             /// <param name="domain">The name of the domain</param>
@@ -275,7 +275,7 @@ namespace Cake.AWS.Route53
             /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
             /// <param name="name">The name of the DNS record set.</param>
             /// <param name="type">The type of the DNS record set.</param>
-            /// <param name="value">The value of the record set.</param> 
+            /// <param name="value">The value of the record set.</param>
             /// <param name="ttl">The time to live of the record set.</param>
             /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
             public string CreateResourceRecordSet(string hostedZoneId, string name, RRType type, string value, long ttl, Route53Settings settings)
@@ -333,13 +333,17 @@ namespace Cake.AWS.Route53
             /// <param name="hostedZoneId">The ID of the hosted zone that contains the resource record sets that you want to change</param>
             /// <param name="name">The name of the DNS record set.</param>
             /// <param name="type">The type of the DNS record set.</param>
+            /// <param name="value">The value of the record set.</param>
+            /// <param name="ttl">The time to live of the record set.</param>
             /// <param name="settings">The <see cref="Route53Settings"/> required to upload to Amazon S3.</param>
-            public string DeleteResourceRecordSet(string hostedZoneId, string name, RRType type, Route53Settings settings)
+            public string DeleteResourceRecordSet(string hostedZoneId, string name, RRType type, string value, long ttl, Route53Settings settings)
             {
                 var recordSet = new ResourceRecordSet()
                 {
                     Name = name,
-                    Type = type
+                    Type = type,
+                    TTL = ttl,
+                    ResourceRecords = new List<ResourceRecord> { new ResourceRecord(value) }
                 };
 
                 var change1 = new Change()

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -6,8 +6,8 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("Cake.AWS.Route53")]
-[assembly: AssemblyVersion("0.0.5")]
-[assembly: AssemblyFileVersion("0.0.5")]
-[assembly: AssemblyInformationalVersion("0.0.5")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2016 Phillip Sharpe")]
+[assembly: AssemblyVersion("0.0.6")]
+[assembly: AssemblyFileVersion("0.0.6")]
+[assembly: AssemblyInformationalVersion("0.0.6")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Phillip Sharpe")]
 


### PR DESCRIPTION
This PR fixes #3. Allows callers to make valid DeleteResourceRecordSet requests.
Without the TTL and backend value for a record, DELETE requests are not valid.

I didn't change the package version in SolutionInfo, but let me know if you'd like me to do that pre-merge