### PR TITLE
fix #6: update cake to v 0.18.0

### DIFF
--- a/src/Route53/packages.config
+++ b/src/Route53/packages.config
@@ -3,5 +3,5 @@
   <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.EC2" version="3.1.13.0" targetFramework="net45" />
   <package id="AWSSDK.Route53" version="3.1.4.0" targetFramework="net45" />
-  <package id="Cake.Core" version="0.11.0" targetFramework="net45" />
+  <package id="Cake.Core" version="0.18.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
can't use this plugin with newer versions of cake, so i figured i'd update.
build passes just fine.

haven't updated a nuget package version for Cake.AWS.Route53, figured you'd do that as part of release.